### PR TITLE
Fix camera glitch and npc memory

### DIFF
--- a/src/xrEngine/CameraManager.cpp
+++ b/src/xrEngine/CameraManager.cpp
@@ -204,7 +204,7 @@ void CCameraManager::UpdateDeffered()
         RemoveCamEffector((*it)->eType);
 
         if ((*it)->AbsolutePositioning())
-            m_EffectorsCam.push_front(*it);
+			m_EffectorsCam.insert(m_EffectorsCam.begin(), *it);
         else
             m_EffectorsCam.push_back(*it);
     }
@@ -363,9 +363,8 @@ bool CCameraManager::ProcessCameraEffector(CEffectorCam* eff)
 void CCameraManager::UpdateCamEffectors()
 {
     if (m_EffectorsCam.empty()) return;
-    EffectorCamVec::reverse_iterator rit = m_EffectorsCam.rbegin();
-    for (; rit != m_EffectorsCam.rend(); ++rit)
-        ProcessCameraEffector(*rit);
+	for (int i = m_EffectorsCam.size() - 1; i >= 0; --i)
+		ProcessCameraEffector(m_EffectorsCam[i]);
 
     m_cam_info.d.normalize();
     m_cam_info.n.normalize();

--- a/src/xrEngine/CameraManager.h
+++ b/src/xrEngine/CameraManager.h
@@ -88,7 +88,7 @@ struct ENGINE_API SPPInfo
     void validate(LPCSTR str);
 };
 
-DEFINE_LIST(CEffectorCam*, EffectorCamVec, EffectorCamIt);
+DEFINE_VECTOR(CEffectorCam*, EffectorCamVec, EffectorCamIt);
 DEFINE_VECTOR(CEffectorPP*, EffectorPPVec, EffectorPPIt);
 
 #define effCustomEffectorStartID 10000

--- a/src/xrGame/hit_memory_manager.cpp
+++ b/src/xrGame/hit_memory_manager.cpp
@@ -337,12 +337,12 @@ void CHitMemoryManager::load	(IReader &packet)
 #ifdef USE_LEVEL_TIME
 		VERIFY						(Device.dwTimeGlobal >= object.m_level_time);
 		object.m_level_time			= packet.r_u32();
-		object.m_level_time			+= Device.dwTimeGlobal;
+		object.m_level_time			= Device.dwTimeGlobal - object.m_level_time;
 #endif // USE_LEVEL_TIME
 #ifdef USE_LAST_LEVEL_TIME
 		VERIFY						(Device.dwTimeGlobal >= object.m_last_level_time);
 		object.m_last_level_time	= packet.r_u32();
-		object.m_last_level_time	+= Device.dwTimeGlobal;
+		object.m_last_level_time	= Device.dwTimeGlobal - object.m_last_level_time;
 #endif // USE_LAST_LEVEL_TIME
 #ifdef USE_FIRST_LEVEL_TIME
 		VERIFY						(Device.dwTimeGlobal >= (*I).m_first_level_time);

--- a/src/xrGame/sound_memory_manager.cpp
+++ b/src/xrGame/sound_memory_manager.cpp
@@ -454,12 +454,12 @@ void CSoundMemoryManager::load	(IReader &packet)
 #ifdef USE_LEVEL_TIME
 		VERIFY						(Device.dwTimeGlobal >= object.m_level_time);
 		object.m_level_time			= packet.r_u32();
-		object.m_level_time			+= Device.dwTimeGlobal;
+		object.m_level_time			= Device.dwTimeGlobal - object.m_level_time;
 #endif // USE_LEVEL_TIME
 #ifdef USE_LAST_LEVEL_TIME
 		VERIFY						(Device.dwTimeGlobal >= object.m_last_level_time);
 		object.m_last_level_time	= packet.r_u32();
-		object.m_last_level_time	+= Device.dwTimeGlobal;
+		object.m_last_level_time	= Device.dwTimeGlobal - object.m_last_level_time;
 #endif // USE_LAST_LEVEL_TIME
 #ifdef USE_FIRST_LEVEL_TIME
 		VERIFY						(Device.dwTimeGlobal >= (*I).m_first_level_time);

--- a/src/xrGame/visual_memory_manager.cpp
+++ b/src/xrGame/visual_memory_manager.cpp
@@ -857,12 +857,12 @@ void CVisualMemoryManager::load	(IReader &packet)
 #ifdef USE_LEVEL_TIME
 		VERIFY						(Device.dwTimeGlobal >= object.m_level_time);
 		object.m_level_time			= packet.r_u32();
-		object.m_level_time			+= Device.dwTimeGlobal;
+		object.m_level_time			= Device.dwTimeGlobal - object.m_level_time;
 #endif // USE_LEVEL_TIME
 #ifdef USE_LAST_LEVEL_TIME
 		VERIFY						(Device.dwTimeGlobal >= object.m_last_level_time);
 		object.m_last_level_time	= packet.r_u32();
-		object.m_last_level_time	+= Device.dwTimeGlobal;
+		object.m_last_level_time	= Device.dwTimeGlobal - object.m_last_level_time;
 #endif // USE_LAST_LEVEL_TIME
 #ifdef USE_FIRST_LEVEL_TIME
 		VERIFY						(Device.dwTimeGlobal >= (*I).m_first_level_time);


### PR DESCRIPTION
1. Fix camera glitch when you reload a weapon and left/right walk.
2. Fix incorrect load npc's memory,